### PR TITLE
Parse negative time durations as 0ms (e.g. 'go wtime -1000')

### DIFF
--- a/src/uci/command/parse.rs
+++ b/src/uci/command/parse.rs
@@ -146,10 +146,10 @@ fn parse_u128_attr(attr: &str, value: &str) -> Result<u128, String> {
 
 fn parse_duration_attr(attr: &str, value: &str) -> Result<Duration, String> {
     let ms = value
-        .parse::<u64>()
+        .parse::<i128>()
         .map_err(|_| format!("invalid value for '{attr}' attribute"))?;
 
-    Ok(Duration::from_millis(ms))
+    Ok(Duration::from_millis(ms.max(0) as u64))
 }
 
 #[cfg(test)]

--- a/src/uci/time.rs
+++ b/src/uci/time.rs
@@ -20,7 +20,7 @@ use std::time::Duration;
 //
 pub fn calculate_allocated_time(time_left: Duration, time_inc: Option<Duration>) -> Option<Duration> {
     if time_left.as_millis() == 0 {
-        return None;
+        return Some(time_left);
     }
 
     let reserve = (time_left / 20).max(Duration::from_millis(50));
@@ -91,6 +91,6 @@ mod tests {
 
         let allocated = calculate_allocated_time(time_left, increment);
 
-        assert_eq!(allocated, None);
+        assert_eq!(allocated, Some(Duration::from_millis(0)));
     }
 }


### PR DESCRIPTION
Fixes https://github.com/tomcant/chess-rs/issues/17