### PR TITLE
Add basic implementation of null-move pruning

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,12 @@ A UCI compatible chess engine written in Rust.
 
 - Move generation
   - Bitboards for pseudo-legal move generation
-  - Sliding piece attack generation
+  - [Fancy magic](https://www.chessprogramming.org/Magic_Bitboards#Fancy) sliding piece attacks
 - Search
   - Iterative deepening
-  - Negamax with alpha/beta pruning
   - Aspiration search
+  - Negamax with alpha/beta pruning
+  - Null-move pruning
   - Principal variation search
   - Quiescence search
   - Check extension


### PR DESCRIPTION
This seems to bring a significant strength increase:

```
Results of variant vs control (10+0.1, NULL, 64MB, 8moves_v3.pgn):
Elo: 137.34 +/- 37.67, nElo: 167.01 +/- 41.14
LOS: 100.00 %, DrawRatio: 28.47 %, PairsRatio: 5.12
Games: 274, Wins: 159, Losses: 56, Draws: 59, Points: 188.5 (68.80 %)
Ptnml(0-2): [6, 10, 39, 39, 43], WL/DD Ratio: 6.80
LLR: 2.95 (100.1%) (-2.94, 2.94) [0.00, 10.00]
--------------------------------------------------
SPRT ([0.00, 10.00]) completed - H1 was accepted
```

(control was the main branch, variant was this PR branch which was up-to-date with main at the time of the test)