### PR TITLE
Optimise the release build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,7 @@ lazy_static = "1.5.0"
 smallvec = "1.15.1"
 
 [profile.release]
+codegen-units = 1
+lto = true
+panic = "abort"
 strip = true


### PR DESCRIPTION
Initial tests show a ~2M nodes/second improvement for perft(6) on an Apple M4 Max.