### PR TITLE
Add futility pruning

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A UCI compatible chess engine written in Rust.
   - Aspiration search
   - Negamax with alpha/beta pruning
   - Null-move pruning
+  - Futility pruning
   - Principal variation search
   - Quiescence search
   - Check extension

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -8,8 +8,8 @@ mod psqt;
 pub const EVAL_MAX: i32 = 10_000;
 pub const EVAL_MIN: i32 = -EVAL_MAX;
 pub const EVAL_DRAW: i32 = 0;
-pub const EVAL_CHECKMATE: i32 = EVAL_MAX;
-pub const EVAL_CHECKMATE_THRESHOLD: i32 = EVAL_CHECKMATE - MAX_DEPTH as i32;
+pub const EVAL_MATE: i32 = EVAL_MAX;
+pub const EVAL_MATE_THRESHOLD: i32 = EVAL_MATE - MAX_DEPTH as i32;
 
 pub fn eval(pos: &Position) -> i32 {
     let eval = (material::eval(White, &pos.board) - material::eval(Black, &pos.board))

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -37,7 +37,7 @@ pub fn search(pos: &mut Position, reporter: &impl Reporter, stopper: &Stopper) {
         let mut pv = MoveList::new();
 
         // Bypass aspiration search for shallow depths or near-mate situations
-        let do_aspiration_search = depth >= ASP_MIN_DEPTH && last_eval.abs() < EVAL_CHECKMATE_THRESHOLD;
+        let do_aspiration_search = depth >= ASP_MIN_DEPTH && last_eval.abs() < EVAL_MATE_THRESHOLD;
         let (mut delta_low, mut delta_high) = (ASP_BASE_DELTA, ASP_BASE_DELTA);
 
         let (mut alpha, mut beta) = if do_aspiration_search {

--- a/src/search/report.rs
+++ b/src/search/report.rs
@@ -30,11 +30,11 @@ impl Report {
     pub fn moves_until_mate(&self) -> Option<u8> {
         let (_, eval) = self.pv.clone()?;
 
-        if eval.abs() < EVAL_CHECKMATE_THRESHOLD || eval.abs() > EVAL_CHECKMATE {
+        if eval.abs() < EVAL_MATE_THRESHOLD || eval.abs() > EVAL_MATE {
             return None;
         }
 
-        Some((EVAL_CHECKMATE - eval.abs()) as u8)
+        Some((EVAL_MATE - eval.abs()) as u8)
     }
 }
 

--- a/src/search/tt.rs
+++ b/src/search/tt.rs
@@ -1,4 +1,4 @@
-use crate::eval::EVAL_CHECKMATE_THRESHOLD;
+use crate::eval::EVAL_MATE_THRESHOLD;
 use crate::movegen::Move;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -84,9 +84,9 @@ impl TranspositionTable {
 // evals are returned unchanged.
 #[inline]
 pub fn eval_in(eval: i32, ply: u8) -> i32 {
-    if eval >= EVAL_CHECKMATE_THRESHOLD {
+    if eval >= EVAL_MATE_THRESHOLD {
         eval + ply as i32
-    } else if eval <= -EVAL_CHECKMATE_THRESHOLD {
+    } else if eval <= -EVAL_MATE_THRESHOLD {
         eval - ply as i32
     } else {
         eval
@@ -98,9 +98,9 @@ pub fn eval_in(eval: i32, ply: u8) -> i32 {
 // current node. Non-mate evals are returned unchanged.
 #[inline]
 pub fn eval_out(eval: i32, ply: u8) -> i32 {
-    if eval >= EVAL_CHECKMATE_THRESHOLD {
+    if eval >= EVAL_MATE_THRESHOLD {
         eval - ply as i32
-    } else if eval <= -EVAL_CHECKMATE_THRESHOLD {
+    } else if eval <= -EVAL_MATE_THRESHOLD {
         eval + ply as i32
     } else {
         eval


### PR DESCRIPTION
SPRT result of this branch vs the main branch:
```
Results of variant vs control (10+0.1, NULL, 64MB, 8moves_v3.pgn):
Elo: 60.00 +/- 24.03, nElo: 74.90 +/- 29.36
LOS: 100.00 %, DrawRatio: 36.06 %, PairsRatio: 2.13
Games: 538, Wins: 235, Losses: 143, Draws: 160, Points: 315.0 (58.55 %)
Ptnml(0-2): [18, 37, 97, 69, 48], WL/DD Ratio: 2.59
LLR: 2.96 (100.4%) (-2.94, 2.94) [0.00, 10.00]
--------------------------------------------------
SPRT ([0.00, 10.00]) completed - H1 was accepted
```