### PR TITLE
Add reverse futility pruning

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Anodos is a UCI-compatible chess engine written in Rust. Built from scratch with
   - Aspiration windows
   - Negamax with alpha/beta pruning
   - Null-move pruning
-  - Futility pruning
+  - Extended/reverse futility pruning
   - Principal variation search
   - Quiescence search
   - Check extension
@@ -43,7 +43,6 @@ Anodos is a UCI-compatible chess engine written in Rust. Built from scratch with
 ## Roadmap
 
 - Search
-  - Reverse futility pruning
   - Late move reductions
   - History heuristic
   - Counter-move heuristic


### PR DESCRIPTION
```
Results of variant vs control (10+0.1, NULL, 64MB, 8moves_v3.pgn):
Elo: 18.89 +/- 12.22, nElo: 24.84 +/- 16.03
LOS: 99.88 %, DrawRatio: 41.57 %, PairsRatio: 1.28
Games: 1804, Wins: 673, Losses: 575, Draws: 556, Points: 951.0 (52.72 %)
Ptnml(0-2): [71, 160, 375, 192, 104], WL/DD Ratio: 2.68
LLR: 2.95 (100.2%) (-2.94, 2.94) [0.00, 10.00]
--------------------------------------------------
SPRT ([0.00, 10.00]) completed - H1 was accepted
```