### PR TITLE
Add a 'bench' command that will be used for PGO compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ stop
 quit
 ```
 
-## Additional Commands
+## Non-standard Commands
 
 Beyond the UCI protocol, the engine supports these debugging/utility commands:
 
@@ -86,6 +86,17 @@ Beyond the UCI protocol, the engine supports these debugging/utility commands:
 | `printboard` | Display the current position |
 | `printfen` | Output the current position as a FEN string |
 | `domove <move>` | Make a move on the current position (e.g., `domove e2e4`) |
+
+## Benchmarking
+
+To measure the engine's nodes-per-second performance, run the binary as follows:
+
+```sh
+./anodos bench [--depth <DEPTH>] [--tt-mb <MB>]
+```
+
+- `--depth` (default: 12) sets the search depth for each position
+- `--tt-mb` (default: 64) sets the transposition table size in MB
 
 
 [build-link]: https://github.com/tomcant/anodos/actions/workflows/ci.yml

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,7 @@ fn main() {
     let args: Vec<_> = std::env::args().collect();
 
     match args.get(1).map(|s| s.as_str()) {
-        Some("bench") => bench::run(),
+        Some("bench") => bench::run(&args[2..]),
         _ => uci::main(),
     }
 }


### PR DESCRIPTION
I'll start compiling the engine with [Profile-guided Optimization](https://doc.rust-lang.org/beta/rustc/profile-guided-optimization.html) soon, and for that I'll need a way to start a search from the binary invocation (I could pipe input to the running engine but that seems overcomplicated).

Here's what the output looks like when running `./anodos bench` (reduced the number of positions for this screenshot):

<img src="https://github.com/user-attachments/assets/3559ddcf-c4a4-4547-be91-cc16e7371ca8" />