### PR TITLE
Initialise the TT once at startup and reuse it for all searches

### DIFF
--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -25,8 +25,9 @@ const ASP_EXPANSION_FACTOR: i32 = 2;
 const ASP_MAX_RETRIES: u8 = 3;
 
 #[rustfmt::skip]
-pub fn search(pos: &mut Position, reporter: &impl Reporter, stopper: &Stopper) {
-    let mut tt = TranspositionTable::new();
+pub fn search(pos: &mut Position, tt: &mut TranspositionTable, reporter: &impl Reporter, stopper: &Stopper) {
+    tt.clear();
+
     let mut killers = KillerMoves::new();
     let mut report = Report::new();
 
@@ -54,7 +55,7 @@ pub fn search(pos: &mut Position, reporter: &impl Reporter, stopper: &Stopper) {
             let mut retries = 0;
 
             loop {
-                let eval = alphabeta::search(pos, depth, alpha, beta, &mut pv, &mut tt, &mut killers, &mut report, stopper);
+                let eval = alphabeta::search(pos, depth, alpha, beta, &mut pv, tt, &mut killers, &mut report, stopper);
 
                 if (eval > alpha && eval < beta) || stopper.should_stop(&report) {
                     eval_final = eval;
@@ -86,7 +87,7 @@ pub fn search(pos: &mut Position, reporter: &impl Reporter, stopper: &Stopper) {
 
         report.depth = depth;
         report.pv = Some(sanitise_pv(pos.clone(), (pv.clone(), last_eval)));
-        report.tt_stats = (tt.usage, tt.capacity);
+        report.tt_usage = tt.usage();
 
         reporter.send(&report);
     }

--- a/src/search/report.rs
+++ b/src/search/report.rs
@@ -6,7 +6,7 @@ pub struct Report {
     pub ply: u8,
     pub nodes: u128,
     pub pv: Option<(MoveList, i32)>,
-    pub tt_stats: (usize, usize),
+    pub tt_usage: usize,
     started_at: Instant,
 }
 
@@ -18,7 +18,7 @@ impl Report {
             ply: 0,
             nodes: 0,
             pv: None,
-            tt_stats: (0, 0),
+            tt_usage: 0,
             started_at: Instant::now(),
         }
     }

--- a/src/search/tt.rs
+++ b/src/search/tt.rs
@@ -1,20 +1,24 @@
 use crate::eval::EVAL_MATE_THRESHOLD;
 use crate::movegen::Move;
-use std::sync::atomic::{AtomicUsize, Ordering};
+
+pub const MIN_SIZE_MB: usize = 1;
+pub const MAX_SIZE_MB: usize = 4096;
+pub const DEFAULT_SIZE_MB: usize = 64;
 
 pub struct TranspositionTable {
     entries: Vec<Entry>,
-    pub usage: usize,
-    pub capacity: usize,
+    capacity: usize,
+    age: u8,
 }
 
 #[derive(Clone)]
 pub struct Entry {
-    pub key: u64,
+    key: u64,
     pub depth: u8,
     pub eval: i32,
     pub bound: Bound,
     pub mv: Option<Move>,
+    age: u8,
 }
 
 #[derive(Clone)]
@@ -24,10 +28,13 @@ pub enum Bound {
     Upper,
 }
 
-#[allow(clippy::new_without_default)]
 impl TranspositionTable {
-    pub fn new() -> Self {
-        let size_bytes = SIZE_MB.load(Ordering::Relaxed).saturating_mul(1024 * 1024);
+    pub fn new(size_mb: usize) -> Self {
+        if !(MIN_SIZE_MB..=MAX_SIZE_MB).contains(&size_mb) {
+            panic!("invalid transposition table size: {size_mb}mb");
+        }
+
+        let size_bytes = size_mb.saturating_mul(1024 * 1024);
         let capacity = size_bytes / std::mem::size_of::<Entry>();
 
         // We use the nearest lower power of two for capacity so that indexing can
@@ -41,36 +48,48 @@ impl TranspositionTable {
                 eval: 0,
                 bound: Bound::Exact,
                 mv: None,
+                age: 0,
             };
             pow2
         ];
 
         Self {
             entries,
-            usage: 0,
             capacity: pow2,
+            age: 0,
         }
     }
 
     pub fn probe(&self, key: u64) -> Option<&Entry> {
         let entry = &self.entries[self.index(key)];
-        if entry.key == key { Some(entry) } else { None }
+        if entry.key == key && entry.age == self.age { Some(entry) } else { None }
     }
 
     pub fn store(&mut self, key: u64, depth: u8, eval: i32, bound: Bound, mv: Option<Move>) {
         let index = self.index(key);
         let entry = &mut self.entries[index];
 
-        if depth >= entry.depth {
-            if entry.key == 0 {
-                self.usage += 1;
-            }
+        if depth >= entry.depth || entry.age != self.age {
             entry.key = key;
             entry.depth = depth;
             entry.eval = eval;
             entry.bound = bound;
             entry.mv = mv;
+            entry.age = self.age;
         }
+    }
+
+    pub fn usage(&self) -> usize {
+        // Assume the first 1000 entries are representative of the table.
+        self.entries
+            .iter()
+            .take(1000)
+            .filter(|entry| entry.age == self.age)
+            .count()
+    }
+
+    pub fn clear(&mut self) {
+        self.age += 1;
     }
 
     #[inline]
@@ -105,17 +124,4 @@ pub fn eval_out(eval: i32, ply: u8) -> i32 {
     } else {
         eval
     }
-}
-
-pub const MIN_SIZE_MB: usize = 1;
-pub const MAX_SIZE_MB: usize = 4096;
-pub const DEFAULT_SIZE_MB: usize = 64;
-
-static SIZE_MB: AtomicUsize = AtomicUsize::new(DEFAULT_SIZE_MB);
-
-pub fn set_size_mb(size_mb: usize) {
-    if !(MIN_SIZE_MB..=MAX_SIZE_MB).contains(&size_mb) {
-        panic!("invalid transposition table size: {size_mb}mb");
-    }
-    SIZE_MB.store(size_mb, Ordering::Relaxed);
 }

--- a/src/uci/command/handle.rs
+++ b/src/uci/command/handle.rs
@@ -2,7 +2,11 @@ use crate::info;
 use crate::movegen::{Move, perft};
 use crate::piece::Piece;
 use crate::position::Position;
-use crate::search::{search, stopper::Stopper, tt};
+use crate::search::{
+    search,
+    stopper::Stopper,
+    tt::{self, TranspositionTable},
+};
 use crate::uci::{r#move::UciMove, reporter::UciReporter};
 use std::time::Instant;
 
@@ -74,9 +78,9 @@ pub fn position(fen: String, moves: Vec<UciMove>, pos: &mut Position) {
     }
 }
 
-pub fn go(pos: &mut Position, stopper: &Stopper) {
+pub fn go(pos: &mut Position, tt: &mut TranspositionTable, stopper: &Stopper) {
     let reporter = UciReporter::new();
-    search(pos, &reporter, stopper);
+    search(pos, tt, &reporter, stopper);
 
     match reporter.best_move() {
         Some(mv) => println!("bestmove {mv}"),
@@ -84,9 +88,12 @@ pub fn go(pos: &mut Position, stopper: &Stopper) {
     }
 }
 
-pub fn set_option(name: String, value: Option<String>) {
+pub fn set_option(name: String, value: Option<String>, tt: &mut TranspositionTable) {
     match name.as_str() {
-        "hash" => tt::set_size_mb(value.unwrap().parse().unwrap()),
+        "hash" => {
+            let size_mb = value.unwrap().parse().unwrap();
+            *tt = TranspositionTable::new(size_mb);
+        }
         _ => panic!("unknown option '{name}'"),
     }
 }

--- a/src/uci/reporter.rs
+++ b/src/uci/reporter.rs
@@ -24,7 +24,7 @@ impl Reporter for UciReporter {
             format!("depth {}", report.depth),
             format!("nodes {}", report.nodes),
             format!("nps {}", report.nodes * 1000 / report.elapsed().as_millis().max(1)),
-            format!("hashfull {}", report.tt_stats.0 * 1000 / report.tt_stats.1),
+            format!("hashfull {}", report.tt_usage),
             format!("time {}", report.elapsed().as_millis()),
         ];
 


### PR DESCRIPTION
This should reduce the number of times the engine loses on time, since before this change it would recreate the TT for each search and the time this took wasn't factored into the remaining time the engine had. With this change, all searches will use the same TT with a new `age` attribute so that entries from previous searches can be ignored/overwritten by the current search (each search increments `age`).