### PR TITLE
Use incremental move picking instead of sorting at every node

### DIFF
--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -5,7 +5,7 @@ use self::{
     tt::TranspositionTable,
 };
 use crate::eval::*;
-use crate::movegen::{Move, MoveList};
+use crate::movegen::MoveList;
 use crate::position::Position;
 
 pub mod report;
@@ -14,6 +14,7 @@ pub mod tt;
 
 mod alphabeta;
 mod killers;
+mod movepicker;
 mod quiescence;
 
 pub const MAX_DEPTH: u8 = u8::MAX;

--- a/src/search/movepicker.rs
+++ b/src/search/movepicker.rs
@@ -1,0 +1,196 @@
+use super::killers::KillerMoves;
+use crate::eval::material;
+use crate::movegen::{MAX_MOVES, Move, generate_all_moves, generate_non_quiet_moves};
+use crate::piece::Piece;
+use crate::position::Position;
+use smallvec::SmallVec;
+
+const SCORE_CAPTURE: i32 = 0;
+const SCORE_PROMOTION: i32 = 1;
+const SCORE_KILLER_1: i32 = 2;
+const SCORE_KILLER_2: i32 = 3;
+const SCORE_QUIET: i32 = 4;
+
+pub enum MovePickerMode<'a> {
+    AllMoves { killers: &'a KillerMoves, ply: u8 },
+    NonQuiets,
+}
+
+pub struct MovePicker {
+    moves: SmallVec<[(Move, i32); MAX_MOVES]>,
+    current_index: usize,
+}
+
+impl MovePicker {
+    pub fn new(pos: &Position, mode: MovePickerMode<'_>) -> Self {
+        let moves = match &mode {
+            MovePickerMode::AllMoves { .. } => generate_all_moves(pos),
+            MovePickerMode::NonQuiets => generate_non_quiet_moves(pos),
+        };
+        let mut scored_moves = SmallVec::new();
+
+        match mode {
+            MovePickerMode::AllMoves { killers, ply } => {
+                let killer1 = killers.probe(ply, 0);
+                let killer2 = killers.probe(ply, 1);
+
+                let score = |mv: &Move| {
+                    if let Some(victim) = mv.captured_piece {
+                        let mvv = material::PIECE_WEIGHTS[victim];
+                        let lva = material::PIECE_WEIGHTS[mv.piece];
+                        return SCORE_CAPTURE - mvv * 100 + lva;
+                    }
+
+                    if mv.promotion_piece.is_some() {
+                        return SCORE_PROMOTION;
+                    }
+
+                    if let Some(killer) = killer1
+                        && mv.equals(&killer)
+                    {
+                        return SCORE_KILLER_1;
+                    }
+
+                    if let Some(killer) = killer2
+                        && mv.equals(&killer)
+                    {
+                        return SCORE_KILLER_2;
+                    }
+
+                    SCORE_QUIET
+                };
+                for mv in moves {
+                    scored_moves.push((mv, score(&mv)));
+                }
+            }
+            MovePickerMode::NonQuiets => {
+                for mv in moves {
+                    let mvv = material::PIECE_WEIGHTS[mv.captured_piece.unwrap_or(Piece::pawn(mv.piece.colour()))];
+                    let lva = material::PIECE_WEIGHTS[mv.promotion_piece.unwrap_or(mv.piece)];
+                    scored_moves.push((mv, SCORE_CAPTURE - mvv * 100 + lva));
+                }
+            }
+        };
+
+        Self {
+            moves: scored_moves,
+            current_index: 0,
+        }
+    }
+
+    pub fn pick(&mut self) -> Option<Move> {
+        if self.current_index >= self.moves.len() {
+            return None;
+        }
+
+        let next_index = (self.current_index..self.moves.len())
+            .min_by_key(|&i| self.moves[i].1)
+            .unwrap();
+
+        let (next_move, _) = self.moves[next_index];
+
+        self.moves.swap(self.current_index, next_index);
+        self.current_index += 1;
+
+        Some(next_move)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::colour::Colour;
+    use crate::piece::Piece;
+    use crate::square::Square;
+    use crate::testing::*;
+
+    #[test]
+    fn order_moves_by_mvv_lva_then_promotions_then_killers() {
+        let quiet = make_move(Piece::WP, Square::C4, Square::C5, None);
+        let killer1 = make_move(Piece::WP, Square::A2, Square::A3, None);
+        let killer2 = make_move(Piece::WP, Square::B2, Square::B3, None);
+        let pawn_x_pawn = make_move(Piece::WP, Square::C4, Square::B5, Some(Piece::BP));
+        let pawn_x_queen = make_move(Piece::WP, Square::C4, Square::D5, Some(Piece::BQ));
+        let knight_x_bishop = make_move(Piece::WN, Square::F4, Square::D3, Some(Piece::BB));
+        let knight_x_queen = make_move(Piece::WN, Square::F4, Square::D5, Some(Piece::BQ));
+        let knight_x_rook = make_move(Piece::WN, Square::F4, Square::G6, Some(Piece::BR));
+        let knight_x_knight = make_move(Piece::WN, Square::F4, Square::H3, Some(Piece::BN));
+        let promotion = make_promotion_move(Colour::White, Square::A7, Square::A8, Piece::WQ);
+
+        let killer_ply = 0;
+        let mut killers = KillerMoves::new();
+        killers.store(killer_ply, &killer2);
+        killers.store(killer_ply, &killer1);
+
+        let mut picker = MovePicker::new(
+            &parse_fen("7k/P7/6r1/1p1q4/2P2N2/3b3n/PP6/4K3 w - - 0 1"),
+            MovePickerMode::AllMoves {
+                killers: &killers,
+                ply: killer_ply,
+            },
+        );
+
+        let picked = std::iter::from_fn(|| picker.pick()).collect::<Vec<Move>>();
+
+        let index = |target: &Move| picked.iter().position(|mv| mv == target).unwrap();
+
+        let index_pawn_x_queen = index(&pawn_x_queen);
+        let index_knight_x_queen = index(&knight_x_queen);
+        let index_knight_x_rook = index(&knight_x_rook);
+        let index_knight_x_bishop = index(&knight_x_bishop);
+        let index_knight_x_knight = index(&knight_x_knight);
+        let index_pawn_x_pawn = index(&pawn_x_pawn);
+        let index_promotion = index(&promotion);
+        let index_killer1 = index(&killer1);
+        let index_killer2 = index(&killer2);
+        let index_quiet = index(&quiet);
+
+        // Captures ordered by MVV/LVA.
+        assert!(index_pawn_x_queen < index_knight_x_queen);
+        assert!(index_knight_x_queen < index_knight_x_rook);
+        assert!(index_knight_x_rook < index_knight_x_bishop);
+        assert!(index_knight_x_bishop < index_knight_x_knight);
+        assert!(index_knight_x_knight < index_pawn_x_pawn);
+
+        // Then promotions, then killers, then remaining quiets.
+        assert!(index_pawn_x_pawn < index_promotion);
+        assert!(index_promotion < index_killer1);
+        assert!(index_killer1 < index_killer2);
+        assert!(index_killer2 < index_quiet);
+    }
+
+    #[test]
+    fn non_quiet_order_moves_by_mvv_lva() {
+        let pawn_x_pawn = make_move(Piece::WP, Square::C4, Square::B5, Some(Piece::BP));
+        let pawn_x_queen = make_move(Piece::WP, Square::C4, Square::D5, Some(Piece::BQ));
+        let knight_x_bishop = make_move(Piece::WN, Square::F4, Square::D3, Some(Piece::BB));
+        let knight_x_queen = make_move(Piece::WN, Square::F4, Square::D5, Some(Piece::BQ));
+        let knight_x_rook = make_move(Piece::WN, Square::F4, Square::G6, Some(Piece::BR));
+        let knight_x_knight = make_move(Piece::WN, Square::F4, Square::H3, Some(Piece::BN));
+        let promotion = make_promotion_move(Colour::White, Square::A7, Square::A8, Piece::WQ);
+
+        let mut picker = MovePicker::new(
+            &parse_fen("7k/P7/6r1/1p1q4/2P2N2/3b3n/8/4K3 w - - 0 1"),
+            MovePickerMode::NonQuiets,
+        );
+
+        let picked = std::iter::from_fn(|| picker.pick()).collect::<Vec<Move>>();
+
+        let index = |target: &Move| picked.iter().position(|mv| mv == target).unwrap();
+
+        let index_pawn_x_queen = index(&pawn_x_queen);
+        let index_knight_x_queen = index(&knight_x_queen);
+        let index_knight_x_rook = index(&knight_x_rook);
+        let index_knight_x_bishop = index(&knight_x_bishop);
+        let index_knight_x_knight = index(&knight_x_knight);
+        let index_pawn_x_pawn = index(&pawn_x_pawn);
+        let index_promotion = index(&promotion);
+
+        assert!(index_pawn_x_queen < index_knight_x_queen);
+        assert!(index_knight_x_queen < index_knight_x_rook);
+        assert!(index_knight_x_rook < index_knight_x_bishop);
+        assert!(index_knight_x_bishop < index_knight_x_knight);
+        assert!(index_knight_x_knight < index_pawn_x_pawn);
+        assert!(index_pawn_x_pawn < index_promotion);
+    }
+}

--- a/src/search/quiescence.rs
+++ b/src/search/quiescence.rs
@@ -1,6 +1,8 @@
-use super::*;
-use crate::movegen::{generate_non_quiet_moves, is_in_check};
-use crate::piece::Piece;
+use super::{
+    movepicker::{MovePicker, MovePickerMode},
+    *,
+};
+use crate::movegen::is_in_check;
 
 pub fn search(pos: &mut Position, mut alpha: i32, beta: i32, report: &mut Report) -> i32 {
     report.nodes += 1;
@@ -16,11 +18,9 @@ pub fn search(pos: &mut Position, mut alpha: i32, beta: i32, report: &mut Report
     }
 
     let colour_to_move = pos.colour_to_move;
+    let mut move_picker = MovePicker::new(pos, MovePickerMode::NonQuiets);
 
-    let mut moves = generate_non_quiet_moves(pos);
-    order_moves(&mut moves);
-
-    for mv in moves {
+    while let Some(mv) = move_picker.pick() {
         pos.do_move(&mv);
 
         if is_in_check(colour_to_move, &pos.board) {
@@ -42,53 +42,4 @@ pub fn search(pos: &mut Position, mut alpha: i32, beta: i32, report: &mut Report
     }
 
     alpha
-}
-
-fn order_moves(moves: &mut [Move]) {
-    moves.sort_unstable_by_key(|mv| {
-        let mvv = material::PIECE_WEIGHTS[mv.captured_piece.unwrap_or(Piece::pawn(mv.piece.colour()))];
-        let lva = material::PIECE_WEIGHTS[mv.promotion_piece.unwrap_or(mv.piece)];
-        -(mvv * 100 - lva)
-    });
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::piece::Piece;
-    use crate::square::Square;
-    use crate::testing::*;
-
-    #[test]
-    fn order_moves_by_mvv_lva() {
-        let pawn_captures_pawn = make_move(Piece::WP, Square::C4, Square::B5, Some(Piece::BP));
-        let pawn_captures_queen = make_move(Piece::WP, Square::C4, Square::D5, Some(Piece::BQ));
-        let knight_captures_bishop = make_move(Piece::WN, Square::F4, Square::D3, Some(Piece::BB));
-        let knight_captures_queen = make_move(Piece::WN, Square::F4, Square::D5, Some(Piece::BQ));
-        let knight_captures_rook = make_move(Piece::WN, Square::F4, Square::G6, Some(Piece::BR));
-        let knight_captures_knight = make_move(Piece::WN, Square::F4, Square::H3, Some(Piece::BN));
-
-        let mut moves = [
-            pawn_captures_pawn,
-            pawn_captures_queen,
-            knight_captures_bishop,
-            knight_captures_queen,
-            knight_captures_rook,
-            knight_captures_knight,
-        ];
-
-        order_moves(&mut moves);
-
-        assert_eq!(
-            moves,
-            [
-                pawn_captures_queen,
-                knight_captures_queen,
-                knight_captures_rook,
-                knight_captures_bishop,
-                knight_captures_knight,
-                pawn_captures_pawn,
-            ],
-        );
-    }
 }

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -1,3 +1,4 @@
+use crate::colour::Colour;
 use crate::movegen::Move;
 use crate::piece::Piece;
 use crate::position::Position;
@@ -16,6 +17,17 @@ pub fn make_move(piece: Piece, from: Square, to: Square, captured_piece: Option<
         to,
         captured_piece,
         promotion_piece: None,
+        is_en_passant: false,
+    }
+}
+
+pub fn make_promotion_move(colour: Colour, from: Square, to: Square, piece: Piece) -> Move {
+    Move {
+        piece: Piece::pawn(colour),
+        from,
+        to,
+        captured_piece: None,
+        promotion_piece: Some(piece),
         is_en_passant: false,
     }
 }


### PR DESCRIPTION
This replaces full per-node move sorting with incremental move picking: score moves once and then use a selection sort-style pass (pick best remaining move/index, swap pairs) to retrieve the next best move on demand. This reduces overhead vs sorting the entire move list at every node while preserving the same move ordering priorities.

A nice little Elo boost for such a simple change:
```
Results of variant vs control (10+0.1, NULL, 64MB, 8moves_v3.pgn):
Elo: 13.51 +/- 7.42, nElo: 18.66 +/- 10.24
LOS: 99.98 %, DrawRatio: 45.96 %, PairsRatio: 1.22
Games: 4426, Wins: 1633, Losses: 1461, Draws: 1332, Points: 2299.0 (51.94 %)
Ptnml(0-2): [162, 377, 1017, 441, 216], WL/DD Ratio: 2.96
LLR: 2.95 (100.3%) (-2.94, 2.94) [0.00, 5.00]
--------------------------------------------------
SPRT ([0.00, 5.00]) completed - H1 was accepted
```