### PR TITLE
Add the history heuristic for ordering quiet moves

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,11 @@ Anodos is a UCI-compatible chess engine written in Rust. Built from scratch with
   - Quiescence search
   - Check extension
   - Transposition table with Zobrist keys
-  - Move ordering heuristics
+  - Move ordering
     - TT move
     - MVV/LVA
     - Killer moves
+    - History heuristic
 - Evaluation
   - Basic material counting
   - Piece-square tables
@@ -44,7 +45,6 @@ Anodos is a UCI-compatible chess engine written in Rust. Built from scratch with
 
 - Search
   - Late move reductions
-  - History heuristic
   - Counter-move heuristic
   - Static exchange evaluation
   - Multi-threading

--- a/src/movegen/move.rs
+++ b/src/movegen/move.rs
@@ -22,6 +22,10 @@ impl Move {
         }
     }
 
+    pub fn is_quiet(&self) -> bool {
+        self.captured_piece.is_none() && self.promotion_piece.is_none()
+    }
+
     pub fn is_castling(&self) -> bool {
         self.piece.is_king() && self.file_diff() > 1
     }

--- a/src/search/history.rs
+++ b/src/search/history.rs
@@ -1,0 +1,23 @@
+use crate::piece::Piece;
+use crate::square::Square;
+
+pub const HISTORY_SCORE_MAX: i32 = 16384;
+
+pub struct HistoryTable {
+    table: [[i32; 64]; 12],
+}
+
+impl HistoryTable {
+    pub fn new() -> Self {
+        Self { table: [[0; 64]; 12] }
+    }
+
+    pub fn probe(&self, piece: Piece, to: Square) -> i32 {
+        self.table[piece][to]
+    }
+
+    pub fn store(&mut self, bonus: i32, piece: Piece, to: Square) {
+        let entry = &mut self.table[piece][to];
+        *entry += bonus - *entry * bonus.abs() / HISTORY_SCORE_MAX;
+    }
+}

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -1,4 +1,5 @@
 use self::{
+    history::HistoryTable,
     killers::KillerMoves,
     report::{Report, Reporter},
     stopper::Stopper,
@@ -13,6 +14,7 @@ pub mod stopper;
 pub mod tt;
 
 mod alphabeta;
+mod history;
 mod killers;
 mod movepicker;
 mod quiescence;
@@ -30,6 +32,7 @@ pub fn search(pos: &mut Position, tt: &mut TranspositionTable, reporter: &impl R
     tt.clear();
 
     let mut killers = KillerMoves::new();
+    let mut history = HistoryTable::new();
     let mut report = Report::new();
 
     let mut last_eval: i32 = 0;
@@ -56,7 +59,7 @@ pub fn search(pos: &mut Position, tt: &mut TranspositionTable, reporter: &impl R
             let mut retries = 0;
 
             loop {
-                let eval = alphabeta::search(pos, depth, alpha, beta, &mut pv, tt, &mut killers, &mut report, stopper);
+                let eval = alphabeta::search(pos, depth, alpha, beta, &mut pv, tt, &mut killers, &mut history, &mut report, stopper);
 
                 if (eval > alpha && eval < beta) || stopper.should_stop(&report) {
                     eval_final = eval;


### PR DESCRIPTION
This adds the [history heuristic](https://www.chessprogramming.org/History_Heuristic) to improve quiet-move ordering during search.

```
Results of variant vs control (10+0.1, NULL, 64MB, 8moves_v3.pgn):
Elo: 52.20 +/- 12.72, nElo: 64.16 +/- 15.39
LOS: 100.00 %, DrawRatio: 38.51 %, PairsRatio: 1.89
Games: 1958, Wins: 855, Losses: 563, Draws: 540, Points: 1125.0 (57.46 %)
Ptnml(0-2): [74, 134, 377, 214, 180], WL/DD Ratio: 2.93
LLR: 2.95 (100.0%) (-2.94, 2.94) [0.00, 3.00]
--------------------------------------------------
SPRT ([0.00, 3.00]) completed - H1 was accepted
```