### PR TITLE
Taper king PSQT by game phase

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 
   [![Build][build-badge]][build-link]
   [![Release][latest-badge]][latest-link]
-  ![Downloads][downloads-badge]
 
 </div>
 
@@ -36,10 +35,10 @@ Anodos is a UCI-compatible chess engine written in Rust. Built from scratch with
     - History heuristic
 - Evaluation
   - Basic material counting
-  - Piece-square tables
+  - MG/EG PSQTs (currently with game phase tapering for the king only)
 - Universal Chess Interface
   - Play via any UCI-compatible GUI (e.g. Cute Chess, En Croissant)
-  - Time management with `movetime` / `wtime` / `btime` / `winc` / `binc`
+  - Basic time management with `movetime` / `wtime` / `btime` / `winc` / `binc`
 
 ## Roadmap
 
@@ -49,12 +48,9 @@ Anodos is a UCI-compatible chess engine written in Rust. Built from scratch with
   - Static exchange evaluation
   - Multi-threading
 - Evaluation
-  - Tapered PSQTs by game phase
-  - Pawn structure, king safety, piece activity
   - Insufficient material draw detection
+  - Tapered PSQTs for all other pieces
   - Syzygy tablebase support
-- Testing
-  - Super-fast perft with a dedicated transposition table
 
 ## Universal Chess Interface
 
@@ -167,8 +163,6 @@ To measure the engine's nodes-per-second performance, run the binary as follows:
 
 [latest-link]: https://github.com/tomcant/anodos/releases/latest
 [latest-badge]: https://img.shields.io/github/v/release/tomcant/anodos?style=for-the-badge&label=latest%20release
-
-[downloads-badge]: https://img.shields.io/github/downloads/tomcant/anodos/total?style=for-the-badge&color=blue
 
 [fancy-magic-link]: https://www.chessprogramming.org/Magic_Bitboards#Fancy
 

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -3,7 +3,10 @@ use crate::position::Position;
 use crate::search::MAX_DEPTH;
 
 pub mod material;
+mod phase;
 mod psqt;
+
+use phase::{MAX_PHASE, phase};
 
 pub const EVAL_MAX: i32 = 10_000;
 pub const EVAL_MIN: i32 = -EVAL_MAX;
@@ -12,8 +15,18 @@ pub const EVAL_MATE: i32 = EVAL_MAX;
 pub const EVAL_MATE_THRESHOLD: i32 = EVAL_MATE - MAX_DEPTH as i32;
 
 pub fn eval(pos: &Position) -> i32 {
-    let eval = (material::eval(White, &pos.board) - material::eval(Black, &pos.board))
-        + (psqt::eval(White, &pos.board) - psqt::eval(Black, &pos.board));
+    let material = material::eval(White, &pos.board) - material::eval(Black, &pos.board);
+    let non_king_psqt = psqt::eval_non_king(White, &pos.board) - psqt::eval_non_king(Black, &pos.board);
+
+    // King PSQT is the only tapered (MG/EG) term for now.
+    let king_mg = psqt::eval_king_mg(White, &pos.board) - psqt::eval_king_mg(Black, &pos.board);
+    let king_eg = psqt::eval_king_eg(White, &pos.board) - psqt::eval_king_eg(Black, &pos.board);
+
+    let eval_mg = material + non_king_psqt + king_mg;
+    let eval_eg = material + non_king_psqt + king_eg;
+
+    let phase = phase(&pos.board);
+    let eval = (eval_mg * phase + eval_eg * (MAX_PHASE - phase)) / MAX_PHASE;
 
     match pos.colour_to_move {
         White => eval,

--- a/src/eval/phase.rs
+++ b/src/eval/phase.rs
@@ -1,0 +1,32 @@
+use crate::piece::Piece;
+use crate::position::Board;
+
+pub const MAX_PHASE: i32 = 24;
+
+pub fn phase(board: &Board) -> i32 {
+    let knights = board.count_pieces(Piece::WN) + board.count_pieces(Piece::BN);
+    let bishops = board.count_pieces(Piece::WB) + board.count_pieces(Piece::BB);
+    let rooks = board.count_pieces(Piece::WR) + board.count_pieces(Piece::BR);
+    let queens = board.count_pieces(Piece::WQ) + board.count_pieces(Piece::BQ);
+
+    MAX_PHASE.min((knights + bishops + 2 * rooks + 4 * queens) as i32)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::position::Position;
+    use crate::testing::*;
+
+    #[test]
+    fn startpos_has_max_phase() {
+        let pos = Position::startpos();
+        assert_eq!(phase(&pos.board), MAX_PHASE);
+    }
+
+    #[test]
+    fn kings_only_has_zero_phase() {
+        let pos = parse_fen("4k3/8/8/8/8/8/8/4K3 w - - 0 1");
+        assert_eq!(phase(&pos.board), 0);
+    }
+}


### PR DESCRIPTION
This is mostly just an attempt at a "quick fix" for losing so many end-games by poor awareness of king safety. In a follow-up change I'm going to add MG/EG PSQTs for other piece types, and also make some sort of attempt at tuning the values (need to read up on this, Texel?).

```
Results of variant vs control (10+0.1, NULL, 64MB, 8moves_v3.pgn):
Elo: 37.80 +/- 18.28, nElo: 49.87 +/- 23.90
LOS: 100.00 %, DrawRatio: 40.39 %, PairsRatio: 1.63
Games: 812, Wins: 324, Losses: 236, Draws: 252, Points: 450.0 (55.42 %)
Ptnml(0-2): [25, 67, 164, 95, 55], WL/DD Ratio: 2.64
LLR: 2.96 (100.5%) (-2.94, 2.94) [0.00, 10.00]
--------------------------------------------------
SPRT ([0.00, 10.00]) completed - H1 was accepted
```