### PR TITLE
Implement late move reductions to speed up the search for unpromising branches

### DIFF
--- a/src/search/killers.rs
+++ b/src/search/killers.rs
@@ -16,6 +16,10 @@ impl KillerMoves {
         self.moves[ply as usize][index]
     }
 
+    pub fn is_killer(&self, ply: u8, mv: &Move) -> bool {
+        self.moves[ply as usize].iter().any(|k| k.is_some_and(|k| *mv == k))
+    }
+
     pub fn store(&mut self, ply: u8, mv: &Move) {
         let moves = &mut self.moves[ply as usize];
 


### PR DESCRIPTION
```
Results of variant vs control (10+0.1, NULL, 64MB, 8moves_v3.pgn):
Elo: 71.84 +/- 27.26, nElo: 85.71 +/- 31.54
LOS: 100.00 %, DrawRatio: 29.18 %, PairsRatio: 2.11
Games: 466, Wins: 208, Losses: 113, Draws: 145, Points: 280.5 (60.19 %)
Ptnml(0-2): [14, 39, 68, 62, 50], WL/DD Ratio: 2.09
LLR: 2.95 (100.3%) (-2.94, 2.94) [0.00, 10.00]
--------------------------------------------------
SPRT ([0.00, 10.00]) completed - H1 was accepted
```