### PR TITLE
Add mobility evaluation term

### DIFF
--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -1,12 +1,13 @@
-use crate::colour::Colour::*;
+use crate::colour::Colour;
 use crate::position::Position;
 use crate::search::MAX_DEPTH;
 
-pub mod material;
 mod phase;
-mod psqt;
 
-use phase::{MAX_PHASE, phase};
+pub mod terms;
+
+use phase::phase_eval;
+use terms::{EvalTerm, TERMS};
 
 pub const EVAL_MAX: i32 = 10_000;
 pub const EVAL_MIN: i32 = -EVAL_MAX;
@@ -15,21 +16,14 @@ pub const EVAL_MATE: i32 = EVAL_MAX;
 pub const EVAL_MATE_THRESHOLD: i32 = EVAL_MATE - MAX_DEPTH as i32;
 
 pub fn eval(pos: &Position) -> i32 {
-    let material = material::eval(White, &pos.board) - material::eval(Black, &pos.board);
-    let non_king_psqt = psqt::eval_non_king(White, &pos.board) - psqt::eval_non_king(Black, &pos.board);
+    let eval = TERMS.iter().fold(EvalTerm::zero(), |acc, term| {
+        acc + term(Colour::White, &pos.board) - term(Colour::Black, &pos.board)
+    });
 
-    // King PSQT is the only tapered (MG/EG) term for now.
-    let king_mg = psqt::eval_king_mg(White, &pos.board) - psqt::eval_king_mg(Black, &pos.board);
-    let king_eg = psqt::eval_king_eg(White, &pos.board) - psqt::eval_king_eg(Black, &pos.board);
-
-    let eval_mg = material + non_king_psqt + king_mg;
-    let eval_eg = material + non_king_psqt + king_eg;
-
-    let phase = phase(&pos.board);
-    let eval = (eval_mg * phase + eval_eg * (MAX_PHASE - phase)) / MAX_PHASE;
+    let phased_eval = phase_eval(eval, &pos.board);
 
     match pos.colour_to_move {
-        White => eval,
-        _ => -eval,
+        Colour::White => phased_eval,
+        _ => -phased_eval,
     }
 }

--- a/src/eval/phase.rs
+++ b/src/eval/phase.rs
@@ -1,9 +1,16 @@
+use super::terms::EvalTerm;
 use crate::piece::Piece;
 use crate::position::Board;
 
-pub const MAX_PHASE: i32 = 24;
+const MAX_PHASE: i32 = 24;
 
-pub fn phase(board: &Board) -> i32 {
+pub fn phase_eval(eval: EvalTerm, board: &Board) -> i32 {
+    let phase = phase(board);
+
+    (eval.mg() * phase + eval.eg() * (MAX_PHASE - phase)) / MAX_PHASE
+}
+
+fn phase(board: &Board) -> i32 {
     let knights = board.count_pieces(Piece::WN) + board.count_pieces(Piece::BN);
     let bishops = board.count_pieces(Piece::WB) + board.count_pieces(Piece::BB);
     let rooks = board.count_pieces(Piece::WR) + board.count_pieces(Piece::BR);

--- a/src/eval/terms/material.rs
+++ b/src/eval/terms/material.rs
@@ -1,13 +1,16 @@
+use super::EvalTerm;
 use crate::colour::Colour;
 use crate::piece::Piece;
 use crate::position::Board;
 
 pub const PIECE_WEIGHTS: [i32; 12] = [100, 300, 350, 500, 900, 0, 100, 300, 350, 500, 900, 0];
 
-pub fn eval(colour: Colour, board: &Board) -> i32 {
-    Piece::pieces_by_colour(colour).iter().fold(0, |acc, piece| {
+pub fn eval(colour: Colour, board: &Board) -> EvalTerm {
+    let score = Piece::pieces_by_colour(colour).iter().fold(0, |acc, piece| {
         acc + PIECE_WEIGHTS[*piece] * board.count_pieces(*piece) as i32
-    })
+    });
+
+    EvalTerm::unphased(score)
 }
 
 #[cfg(test)]
@@ -19,7 +22,9 @@ mod tests {
     fn more_material_is_good() {
         let more_white_material = parse_fen("4kbnr/8/8/8/8/8/4P3/4KBNR w - - 0 1");
 
-        assert!(eval(Colour::White, &more_white_material.board) > eval(Colour::Black, &more_white_material.board));
+        assert!(
+            eval(Colour::White, &more_white_material.board).mg() > eval(Colour::Black, &more_white_material.board).mg()
+        );
     }
 
     #[test]
@@ -28,10 +33,12 @@ mod tests {
         let black_bishop_white_pawn = parse_fen("5b2/8/8/8/8/8/4P3/8 w - - 0 1");
 
         assert!(
-            eval(Colour::White, &white_knight_black_pawn.board) > eval(Colour::Black, &white_knight_black_pawn.board)
+            eval(Colour::White, &white_knight_black_pawn.board).mg()
+                > eval(Colour::Black, &white_knight_black_pawn.board).mg()
         );
         assert!(
-            eval(Colour::Black, &black_bishop_white_pawn.board) > eval(Colour::White, &black_bishop_white_pawn.board)
+            eval(Colour::Black, &black_bishop_white_pawn.board).mg()
+                > eval(Colour::White, &black_bishop_white_pawn.board).mg()
         );
     }
 
@@ -39,13 +46,13 @@ mod tests {
     fn rooks_are_worth_more_than_bishops() {
         let pos = parse_fen("5b2/8/8/8/8/8/8/7R w - - 0 1");
 
-        assert!(eval(Colour::White, &pos.board) > eval(Colour::Black, &pos.board));
+        assert!(eval(Colour::White, &pos.board).mg() > eval(Colour::Black, &pos.board).mg());
     }
 
     #[test]
     fn queens_are_worth_more_than_rooks() {
         let pos = parse_fen("7r/8/8/8/8/8/8/3Q4 w - - 0 1");
 
-        assert!(eval(Colour::White, &pos.board) > eval(Colour::Black, &pos.board));
+        assert!(eval(Colour::White, &pos.board).mg() > eval(Colour::Black, &pos.board).mg());
     }
 }

--- a/src/eval/terms/mobility.rs
+++ b/src/eval/terms/mobility.rs
@@ -1,0 +1,39 @@
+use super::EvalTerm;
+use crate::colour::Colour;
+use crate::movegen::get_attacks;
+use crate::piece::Piece;
+use crate::position::Board;
+use crate::square::Square;
+
+const KNIGHT_WEIGHTS: (i32, i32) = (4, 4);
+const BISHOP_WEIGHTS: (i32, i32) = (4, 4);
+const ROOK_WEIGHTS: (i32, i32) = (2, 3);
+const QUEEN_WEIGHTS: (i32, i32) = (1, 2);
+
+pub fn eval(colour: Colour, board: &Board) -> EvalTerm {
+    let occupancy = board.pieces_by_colour(colour);
+
+    let knights = mobility(Piece::knight(colour), KNIGHT_WEIGHTS, occupancy, board);
+    let bishops = mobility(Piece::bishop(colour), BISHOP_WEIGHTS, occupancy, board);
+    let rooks = mobility(Piece::rook(colour), ROOK_WEIGHTS, occupancy, board);
+    let queens = mobility(Piece::queen(colour), QUEEN_WEIGHTS, occupancy, board);
+
+    knights + bishops + rooks + queens
+}
+
+#[inline(always)]
+fn mobility(piece: Piece, weights: (i32, i32), occupancy: u64, board: &Board) -> EvalTerm {
+    let (mut mg, mut eg) = (0, 0);
+    let mut pieces = board.pieces(piece);
+
+    while pieces != 0 {
+        let square = Square::next(&mut pieces);
+        let attacks = get_attacks(piece, square, board) & !occupancy;
+        let mobility = attacks.count_ones() as i32;
+
+        mg += mobility * weights.0;
+        eg += mobility * weights.1;
+    }
+
+    EvalTerm::new(mg, eg)
+}

--- a/src/eval/terms/mod.rs
+++ b/src/eval/terms/mod.rs
@@ -1,0 +1,58 @@
+use crate::colour::Colour;
+use crate::position::Board;
+
+mod material;
+mod mobility;
+mod psqt;
+
+pub use material::PIECE_WEIGHTS;
+
+pub const TERMS: [fn(Colour, &Board) -> EvalTerm; 3] = [material::eval, psqt::eval, mobility::eval];
+
+#[derive(Debug, Clone, Copy)]
+pub struct EvalTerm(i32, i32);
+
+impl EvalTerm {
+    #[inline(always)]
+    pub const fn new(mg: i32, eg: i32) -> Self {
+        Self(mg, eg)
+    }
+
+    #[inline(always)]
+    pub const fn zero() -> Self {
+        Self(0, 0)
+    }
+
+    #[inline(always)]
+    pub const fn unphased(eval: i32) -> Self {
+        Self(eval, eval)
+    }
+
+    #[inline(always)]
+    pub const fn mg(self) -> i32 {
+        self.0
+    }
+
+    #[inline(always)]
+    pub const fn eg(self) -> i32 {
+        self.1
+    }
+}
+
+impl std::ops::Add for EvalTerm {
+    type Output = Self;
+
+    #[inline(always)]
+    fn add(self, rhs: Self) -> Self::Output {
+        Self(self.mg() + rhs.mg(), self.eg() + rhs.eg())
+    }
+}
+
+impl std::ops::Sub for EvalTerm {
+    type Output = Self;
+
+    #[inline(always)]
+    fn sub(self, rhs: Self) -> Self::Output {
+        Self(self.mg() - rhs.mg(), self.eg() - rhs.eg())
+    }
+}

--- a/src/eval/terms/psqt.rs
+++ b/src/eval/terms/psqt.rs
@@ -1,3 +1,4 @@
+use super::EvalTerm;
 use crate::colour::Colour;
 use crate::piece::Piece;
 use crate::position::Board;
@@ -7,7 +8,15 @@ use lazy_static::lazy_static;
 type Psqt = [i32; 64];
 
 #[inline(always)]
-pub fn eval_non_king(colour: Colour, board: &Board) -> i32 {
+pub fn eval(colour: Colour, board: &Board) -> EvalTerm {
+    let king_square = Square::first(board.pieces(Piece::king(colour)));
+    let king_term = EvalTerm::new(PSQT_MG_KING[colour][king_square], PSQT_EG_KING[colour][king_square]);
+
+    EvalTerm::unphased(eval_non_king(colour, board)) + king_term
+}
+
+#[inline(always)]
+fn eval_non_king(colour: Colour, board: &Board) -> i32 {
     let pieces = [
         Piece::pawn(colour),
         Piece::knight(colour),
@@ -15,7 +24,6 @@ pub fn eval_non_king(colour: Colour, board: &Board) -> i32 {
         Piece::rook(colour),
         Piece::queen(colour),
     ];
-
     pieces.iter().fold(0, |mut acc, piece| {
         let mut pieces = board.pieces(*piece);
         while pieces != 0 {
@@ -23,20 +31,6 @@ pub fn eval_non_king(colour: Colour, board: &Board) -> i32 {
         }
         acc
     })
-}
-
-#[inline(always)]
-pub fn eval_king_mg(colour: Colour, board: &Board) -> i32 {
-    let king_square = Square::first(board.pieces(Piece::king(colour)));
-
-    PSQT_MG_KING[colour][king_square]
-}
-
-#[inline(always)]
-pub fn eval_king_eg(colour: Colour, board: &Board) -> i32 {
-    let king_square = Square::first(board.pieces(Piece::king(colour)));
-
-    PSQT_EG_KING[colour][king_square]
 }
 
 lazy_static! {

--- a/src/search/movepicker.rs
+++ b/src/search/movepicker.rs
@@ -2,7 +2,7 @@ use super::{
     history::{HISTORY_SCORE_MAX, HistoryTable},
     killers::KillerMoves,
 };
-use crate::eval::material;
+use crate::eval::terms::PIECE_WEIGHTS;
 use crate::movegen::{MAX_MOVES, Move, generate_all_moves, generate_non_quiet_moves};
 use crate::piece::Piece;
 use crate::position::Position;
@@ -43,8 +43,8 @@ impl MovePicker {
 
                 let score = |mv: &Move| {
                     if let Some(victim) = mv.captured_piece {
-                        let mvv = material::PIECE_WEIGHTS[victim];
-                        let lva = material::PIECE_WEIGHTS[mv.piece];
+                        let mvv = PIECE_WEIGHTS[victim];
+                        let lva = PIECE_WEIGHTS[mv.piece];
                         return SCORE_CAPTURE - mvv * 100 + lva;
                     }
 
@@ -72,8 +72,8 @@ impl MovePicker {
             }
             MovePickerMode::NonQuiets => {
                 for mv in moves {
-                    let mvv = material::PIECE_WEIGHTS[mv.captured_piece.unwrap_or(Piece::pawn(mv.piece.colour()))];
-                    let lva = material::PIECE_WEIGHTS[mv.promotion_piece.unwrap_or(mv.piece)];
+                    let mvv = PIECE_WEIGHTS[mv.captured_piece.unwrap_or(Piece::pawn(mv.piece.colour()))];
+                    let lva = PIECE_WEIGHTS[mv.promotion_piece.unwrap_or(mv.piece)];
                     scored_moves.push((mv, SCORE_CAPTURE - mvv * 100 + lva));
                 }
             }


### PR DESCRIPTION
```
Results of variant vs control (10+0.1, NULL, 64MB, 8moves_v3.pgn):
Elo: 52.72 +/- 16.37, nElo: 64.81 +/- 19.81
LOS: 100.00 %, DrawRatio: 34.18 %, PairsRatio: 1.82
Games: 1182, Wins: 483, Losses: 305, Draws: 394, Points: 680.0 (57.53 %)
Ptnml(0-2): [40, 98, 202, 146, 105], WL/DD Ratio: 1.69
LLR: 2.95 (100.3%) (-2.94, 2.94) [0.00, 5.00]
--------------------------------------------------
SPRT ([0.00, 5.00]) completed - H1 was accepted
```