### PR TITLE
Evaluate rooks on open and half-open files

### DIFF
--- a/src/eval/terms/mod.rs
+++ b/src/eval/terms/mod.rs
@@ -5,10 +5,12 @@ mod material;
 mod mobility;
 mod pawns;
 mod psqt;
+mod rooks;
 
 pub use material::PIECE_WEIGHTS;
 
-pub const TERMS: [fn(Colour, &Board) -> EvalTerm; 4] = [material::eval, mobility::eval, pawns::eval, psqt::eval];
+pub static TERMS: [fn(Colour, &Board) -> EvalTerm; 5] =
+    [material::eval, mobility::eval, pawns::eval, psqt::eval, rooks::eval];
 
 #[derive(Debug, Clone, Copy)]
 pub struct EvalTerm(i32, i32);

--- a/src/eval/terms/rooks.rs
+++ b/src/eval/terms/rooks.rs
@@ -1,0 +1,33 @@
+use super::EvalTerm;
+use crate::colour::Colour;
+use crate::piece::Piece;
+use crate::position::Board;
+use crate::square::{FILES, Square};
+
+const OPEN_FILE_MG: i32 = 15;
+const OPEN_FILE_EG: i32 = 10;
+
+const HALF_OPEN_FILE_MG: i32 = 8;
+const HALF_OPEN_FILE_EG: i32 = 6;
+
+pub fn eval(colour: Colour, board: &Board) -> EvalTerm {
+    let (mut mg, mut eg) = (0, 0);
+    let mut our_rooks = board.pieces(Piece::rook(colour));
+    let our_pawns = board.pieces(Piece::pawn(colour));
+    let all_pawns = our_pawns | board.pieces(Piece::pawn(colour.flip()));
+
+    while our_rooks != 0 {
+        let square = Square::next(&mut our_rooks);
+        let file = FILES[square.file() as usize];
+
+        if all_pawns & file == 0 {
+            mg += OPEN_FILE_MG;
+            eg += OPEN_FILE_EG;
+        } else if our_pawns & file == 0 {
+            mg += HALF_OPEN_FILE_MG;
+            eg += HALF_OPEN_FILE_EG;
+        }
+    }
+
+    EvalTerm::new(mg, eg)
+}


### PR DESCRIPTION
```
Results of variant vs control (10+0.1, NULL, 64MB, 8moves_v3.pgn):
Elo: 33.10 +/- 12.70, nElo: 41.27 +/- 15.73
LOS: 100.00 %, DrawRatio: 32.23 %, PairsRatio: 1.53
Games: 1874, Wins: 686, Losses: 508, Draws: 680, Points: 1026.0 (54.75 %)
Ptnml(0-2): [77, 174, 302, 262, 122], WL/DD Ratio: 1.48
LLR: 2.95 (100.3%) (-2.94, 2.94) [0.00, 5.00]
--------------------------------------------------
SPRT ([0.00, 5.00]) completed - H1 was accepted
```